### PR TITLE
[UPDATE] Urls to files in src/data/

### DIFF
--- a/docs/source/datastructures_peak.rst
+++ b/docs/source/datastructures_peak.rst
@@ -357,8 +357,10 @@ The following example figures were generated using a `mzML file <https://github.
         plt.show() # slow for larger data sets
    
    from urllib.request import urlretrieve
-   
-   urlretrieve('https://raw.githubusercontent.com/OpenMS/OpenMS/develop/src/tests/topp/FeatureFinderMetaboIdent_1_input.mzML', 'test.mzML')
+
+   gh = "https://raw.githubusercontent.com/OpenMS/pyopenms-extra/master"
+   urlretrieve (gh + "/src/data/FeatureFinderMetaboIdent_1_input.mzML", "test.mzML")
+
    exp = MSExperiment()
    MzMLFile().load('test.mzML', exp)
    

--- a/docs/source/feature_detection.rst
+++ b/docs/source/feature_detection.rst
@@ -29,7 +29,7 @@ in MS data:
 
   from urllib.request import urlretrieve
   gh = "https://raw.githubusercontent.com/OpenMS/pyopenms-extra/master"
-  urlretrieve (gh +"/src/data/FeatureFinderCentroided_1_input.mzML", "feature_test.mzML")
+  urlretrieve (gh + "/src/data/FeatureFinderCentroided_1_input.mzML", "feature_test.mzML")
 
   from pyopenms import *
 

--- a/docs/source/hyperscore.rst
+++ b/docs/source/hyperscore.rst
@@ -23,7 +23,7 @@ loaded from an mzML file.
     from urllib.request import urlretrieve
     from pyopenms import *
     gh = "https://raw.githubusercontent.com/OpenMS/pyopenms-extra/master"
-    urlretrieve (gh +"/src/data/SimpleSearchEngine_1.mzML", "searchfile.mzML")
+    urlretrieve (gh + "/src/data/SimpleSearchEngine_1.mzML", "searchfile.mzML")
 
 Generate a theoretical spectrum
 *******************************

--- a/docs/source/mzqc_export.rst
+++ b/docs/source/mzqc_export.rst
@@ -22,7 +22,7 @@ proteomics and metabolomics quality metrics.
     output_file = 'result.mzQC'
 
     # load mzML file in MSExperiment
-    urlretrieve(gh + "/src/data/QCCalculator_input.mzML", 'input.mzML')
+    urlretrieve (gh + "/src/data/QCCalculator_input.mzML", 'input.mzML')
     exp = MSExperiment()
     MzMLFile().load('input.mzML', exp)
 
@@ -34,13 +34,13 @@ proteomics and metabolomics quality metrics.
 
     feature_map = FeatureMap()
     # OPTIONAL: load featureXML file in FeatureMap()
-    urlretrieve(gh + "/src/data/FeatureFinderMetaboIdent_1_output.featureXML", 'features.featureXML')
+    urlretrieve (gh + "/src/data/FeatureFinderMetaboIdent_1_output.featureXML", 'features.featureXML')
     FeatureXMLFile().load('features.featureXML', feature_map)
 
     prot_ids = [] # list of ProteinIdentification()
     pep_ids = [] # list of PeptideIdentification()
     # OPTIONAL: get protein and peptide identifications from idXML file
-    urlretrieve(gh + "/src/data/OpenPepXL_output.idXML", 'ids.idXML')
+    urlretrieve (gh + "/src/data/OpenPepXL_output.idXML", 'ids.idXML')
     IdXMLFile().load('ids.idXML', prot_ids, pep_ids)
 
     # create MzQCFile object and use store() to calculate and write the mzQC file

--- a/docs/source/smoothing.rst
+++ b/docs/source/smoothing.rst
@@ -8,8 +8,8 @@ further analysis
 
   from urllib.request import urlretrieve
   from pyopenms import *
-  gh = "https://raw.githubusercontent.com/OpenMS/OpenMS/develop"
-  urlretrieve (gh +"/share/OpenMS/examples/peakpicker_tutorial_1_baseline_filtered.mzML", "tutorial.mzML")
+  gh = "https://raw.githubusercontent.com/OpenMS/pyopenms-extra/master"
+  urlretrieve (gh +"/src/data/peakpicker_tutorial_1_baseline_filtered.mzML", "tutorial.mzML")
 
   exp = MSExperiment()
   gf = GaussFilter()


### PR DESCRIPTION
fixes #76

Some of the URLs were set incorrectly. All files are already in `src/data/`.

Please let me know if you think anything else is missing. 

IMHO should be all:
```
find . -name "*.rst" -exec grep -H "urlretrieve (" {} \;

./docs/source/smoothing.rst:  urlretrieve (gh +"/src/data/peakpicker_tutorial_1_baseline_filtered.mzML", "tutorial.mzML")
./docs/source/other_file_handling.rst:    urlretrieve (gh + "/src/data/IdXMLFile_whole.idXML", "test.idXML")
./docs/source/other_file_handling.rst:    urlretrieve (gh + "/src/data/MzIdentML_3runs.mzid", "test.mzid")
./docs/source/other_file_handling.rst:    urlretrieve (gh + "/src/data/PepXMLFile_test.pepxml", "test.pepxml")
./docs/source/other_file_handling.rst:    urlretrieve (gh + "/src/data/ProtXMLFile_input_1.protXML", "test.protXML")
./docs/source/other_file_handling.rst:    urlretrieve (gh + "/src/data/FeatureFinderCentroided_1_output.featureXML", "test.featureXML")
./docs/source/other_file_handling.rst:    urlretrieve (gh + "/src/data/ConsensusXMLFile_1.consensusXML", "test.consensusXML")
./docs/source/other_file_handling.rst:    urlretrieve (gh + "/src/data/ConvertTSVToTraML_output.TraML", "test.TraML")
./docs/source/feature_detection.rst:  urlretrieve (gh + "/src/data/FeatureFinderCentroided_1_input.mzML", "feature_test.mzML")
./docs/source/metabolomics_targeted_feature_extraction.rst:  urlretrieve (gh + "/src/data/FeatureFinderMetaboIdent_1_input.mzML", "ms_data.mzML")
./docs/source/metabolomics_targeted_feature_extraction.rst:  urlretrieve (gh + "/src/data/FeatureFinderMetaboIdent_1_input.tsv", "library.tsv")
./docs/source/peptide_search.rst:    urlretrieve (gh +"/src/data/SimpleSearchEngine_1.mzML", "searchfile.mzML")
./docs/source/peptide_search.rst:    urlretrieve (gh +"/src/data/SimpleSearchEngine_1.fasta", "search.fasta")
./docs/source/first_steps.rst:    urlretrieve (gh + "/src/data/tiny.mzML", "tiny.mzML")
./docs/source/first_steps.rst:    urlretrieve (gh + "/src/data/FeatureFinderMetaboIdent_1_input.mzML", "ms_data.mzML")
./docs/source/spectrumalignment.rst:    urlretrieve (gh + "/src/data/YIC(Carbamidomethyl)DNQDTISSK.mzML", "observed.mzML")
./docs/source/file_handling.rst:    urlretrieve (gh + "/src/data/tiny.mzML", "test.mzML")
./docs/source/mzqc_export.rst:    urlretrieve (gh + "/src/data/QCCalculator_input.mzML", 'input.mzML')
./docs/source/mzqc_export.rst:    urlretrieve (gh + "/src/data/FeatureFinderMetaboIdent_1_output.featureXML", 'features.featureXML')
./docs/source/mzqc_export.rst:    urlretrieve (gh + "/src/data/OpenPepXL_output.idXML", 'ids.idXML')
./docs/source/digestion.rst:    urlretrieve (gh + "/src/data/P02769.fasta", "bsa.fasta")
./docs/source/digestion.rst:    urlretrieve (gh + "/src/data/P02769.fasta", "bsa.fasta")
./docs/source/mzMLFileFormat.rst:    urlretrieve (gh + "/src/data/tiny.mzML", "test.mzML")
./docs/source/chromatographic_analysis.rst:    urlretrieve (gh + "/src/data/OpenSwathAnalyzer_1_input_chrom.mzML", "chrom.mzML")
./docs/source/chromatographic_analysis.rst:    urlretrieve (gh + "/src/data/OpenSwathAnalyzer_1_input.TraML", "transitions.TraML")
./docs/source/hyperscore.rst:    urlretrieve (gh + "/src/data/SimpleSearchEngine_1.mzML", "searchfile.mzML")
./docs/source/deisotoping.rst:    urlretrieve (gh + "/src/data/BSA1.mzML", "BSA1.mzML")
./docs/source/algorithms.rst:    urlretrieve (gh + "/src/data/tiny.mzML", "test.mzML")
./docs/source/feature_linking.rst:        urlretrieve (base_url + feature_file, feature_file)
./docs/source/datastructures_peak.rst:   urlretrieve (gh + "/src/data/FeatureFinderMetaboIdent_1_input.mzML", "test.mzML")
./docs/source/datastructures_peak.rst:    urlretrieve (gh + "/src/data/tiny.mzML", "test.mzML")
./docs/source/map_alignment.rst:        urlretrieve (base_url + feature_file, feature_file)
./docs/source/normalization.rst:  urlretrieve (gh + "/src/data/peakpicker_tutorial_1_baseline_filtered.mzML", "tutorial.mzML")
```