### PR TITLE
[Fix] Failing notebooks

### DIFF
--- a/docs/source/GNPS_export.rst
+++ b/docs/source/GNPS_export.rst
@@ -49,5 +49,5 @@ Now you can export your all files for FBMN and IIMN.
     GNPSMetaValueFile().store(consensus_map, "MetaValueTable.tsv")
 
     # for IIMN
-    IonIdentityMolecularNetworking.annotateConsensusMap(consensus_map)
-    iimn.writeSupplementaryPairTable(consensus_map, "SupplementaryPairTable.csv")
+    IonIdentityMolecularNetworking().annotateConsensusMap(consensus_map)
+    IonIdentityMolecularNetworking().writeSupplementaryPairTable(consensus_map, "SupplementaryPairTable.csv")

--- a/docs/source/build_from_source.rst
+++ b/docs/source/build_from_source.rst
@@ -5,7 +5,7 @@ To install pyOpenMS from :index:`source`, you will first have to compile OpenMS
 successfully on your platform of choice (note that for MS Windows you will need
 to match your compiler and Python version). Please follow the `official
 documentation
-<https://abibuilder.informatik.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/index.html>`_
+<https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/index.html>`_
 in order to compile OpenMS for your platform. Next you will need to install the
 following software packages
 

--- a/docs/source/feature_detection.rst
+++ b/docs/source/feature_detection.rst
@@ -144,7 +144,7 @@ specified in an assay library (a tab-separated text file). Detected ``Features``
 stored in a ``FeatureXMLFile``. This tool is useful for the targeted extraction of ``Features`` for a well defined set of compounds 
 with known sum formulas and retention times. 
 For more information on the format of the assay library and available parameters visit the `FeatureFinderMetaboIdent documentation
-<https://abibuilder.informatik.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/UTILS_FeatureFinderMetaboIdent.html>`_.
+<https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/UTILS_FeatureFinderMetaboIdent.html>`_.
 
 
 The pyOpenMS ``FeatureFinderAlgorithmMetaboIdent`` needs a list of ``FeatureFinderMetaboIdentCompound`` objects as an assay libray for it's

--- a/docs/source/first_steps.rst
+++ b/docs/source/first_steps.rst
@@ -92,7 +92,7 @@ We could now continue our investigation by reading the documentation of the
 base classes ``DocumentIdentifier`` and ``MetaInfoInterface``, but we will
 leave this exercise for the interested reader. For a more complete documentation of the underlying
 wrapped methods, please consult the official OpenMS documentation, in this case
-the `MSExperiment documentation <https://abibuilder.informatik.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/classOpenMS_1_1MSExperiment.html>`_.
+the `MSExperiment documentation <https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/classOpenMS_1_1MSExperiment.html>`_.
 
 
 First look at data

--- a/docs/source/id_by_mz.rst
+++ b/docs/source/id_by_mz.rst
@@ -41,7 +41,7 @@ Execute this cell only for the example workflow.
     if not os.path.isdir(os.path.join(os.getcwd(), 'IdByMz_Example')):
         os.mkdir(os.path.join(os.getcwd(), 'IdByMz_Example'))
 
-    base = 'https://abibuilder.informatik.uni-tuebingen.de/archive/openms/Tutorials/Data/latest/Example_Data/Metabolomics/'
+    base = 'https://abibuilder.cs.uni-tuebingen.de/archive/openms/Tutorials/Data/latest/Example_Data/Metabolomics/'
     urls = ['datasets/2012_02_03_PStd_050_1.mzML',
             'datasets/2012_02_03_PStd_050_2.mzML',
             'datasets/2012_02_03_PStd_050_3.mzML',


### PR DESCRIPTION
This fixes some of the [failing notebooks](https://github.com/OpenMS/pyopenms-docs/actions/runs/3183459071/jobs/5190697621) as mentioned in #299. However, there is still an issue in the peptide search tutorial that needs to be solved. At the end in the FDR section the IdXMLFile can not be stored because of invalid protein references.