### PR TITLE
To remove line numbers in the code of Molecular formulae and Isotopes…

### DIFF
--- a/docs/source/chemistry.rst
+++ b/docs/source/chemistry.rst
@@ -243,7 +243,7 @@ addition and subtraction. A simple example is given in the next few lines of
 code.
 
 .. code-block:: python
-    :linenos:
+    
 
     methanol = EmpiricalFormula("CH3OH")
     water = EmpiricalFormula("H2O")
@@ -274,7 +274,7 @@ Specific isotopes can be incorporated into a molecular formula using bracket
 notation. For example, ethanol with one or two C13 can be specified using ``(13)C`` as follows:
 
 .. code-block:: python
-    :linenos:
+    
 
     ethanol = EmpiricalFormula("C2H6O")
     print("Ethanol chemical formula:", ethanol.toString())


### PR DESCRIPTION
… for the ease of users.

Hi, when I copy the code under the headlines "Molecular formulae" and "Isotopes" the line numbers also appear its good for the ease of open MS users to solve this issue.@timosachsenberg @axelwalter @jpfeuffer