### PR TITLE
adding "import matplotlib" in example codes

### DIFF
--- a/docs/source/datastructures_peak.rst
+++ b/docs/source/datastructures_peak.rst
@@ -187,6 +187,7 @@ We can also visualize our spectrum from before using the :py:func:`~.plot_spectr
     :linenos:
 
     from pyopenms.plotting import plot_spectrum
+    import matplotlib.pyplot as plt
 
     plot_spectrum(spectrum)
     plt.show()

--- a/docs/source/spectrumalignment.rst
+++ b/docs/source/spectrumalignment.rst
@@ -48,6 +48,7 @@ Now we can plot the observed and theoretical spectrum as a mirror plot:
     :linenos:
 
     from pyopenms.plotting import mirror_plot_spectrum
+    import matplotlib.pyplot as plt
 
     mirror_plot_spectrum(
         observed_spectrum,
@@ -119,6 +120,7 @@ The mirror plot can also be used to visualize the aligned spectrum:
     :linenos:
 
     from pyopenms.plotting import mirror_plot_spectrum
+    import matplotlib.pyplot as plt
 
     mirror_plot_spectrum(
         observed_spectrum,

--- a/docs/source/theoreticalspectrumgenerator.rst
+++ b/docs/source/theoreticalspectrumgenerator.rst
@@ -49,6 +49,7 @@ which you could plot with :py:func:`~.plot_spectrum`, automatically showing anno
 .. code-block:: python
 
     from pyopenms.plotting import plot_spectrum
+    import matplotlib.pyplot as plt
 
     plot_spectrum(spec1)
     plt.show()
@@ -115,6 +116,7 @@ which you again can visualize with:
 .. code-block:: python
 
     from pyopenms.plotting import plot_spectrum
+    import matplotlib.pyplot as plt
 
     plot_spectrum(spec2, annotate_ions=False)
     plt.show()


### PR DESCRIPTION
import matplotlib part was deleted, but that library is still used