### PR TITLE
choose binder instance able to run our notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ Are created by CI and stored in master+ipynb to not clutter the master branch.
 
 Binder integration
 =============
-Binder uses the Jupyter Notebooks in master+ipynb. The conda environment is described in environment.yml, the post-build event installs the nightly pyopenms wheel. Currently, only environment.yml is used by binder. Note: You can test a branch "jpfeuffer-patch-6" using https://mybinder.org/v2/gh/OpenMS/pyopenms-docs/jpfeuffer-patch-6 
+Binder uses the Jupyter Notebooks in master+ipynb. The conda environment is described in environment.yml, the post-build event installs the nightly pyopenms wheel. Currently, only environment.yml is used by binder. Note: You can test a branch "jpfeuffer-patch-6" using https://notebooks.gesis.org/binder/v2/gh/OpenMS/pyopenms-docs/jpfeuffer-patch-6 

--- a/docs/source/_templates/navbar-run-binder.html
+++ b/docs/source/_templates/navbar-run-binder.html
@@ -1,6 +1,6 @@
 <ul class="navbar-icon-links navbar-nav" aria-label="Custom Icon Links">
   <li class="nav-item">
-    <a href="https://mybinder.org/v2/gh/{{ github_user }}/{{ github_repo }}/{{ github_version }}+ipynb?urlpath=lab/tree/{{ doc_path }}{{ pagename }}.ipynb" class="nav-link" rel="noopener" target="_blank" data-bs-toggle="tooltip" data-bs-original-title="Launch on Binder" data-bs-placement="bottom"><span><i class="fa fa-rocket fa-beat fa-lg"></i></span>
+    <a href="https://notebooks.gesis.org/binder/v2/gh/{{ github_user }}/{{ github_repo }}/{{ github_version }}+ipynb?urlpath=lab/tree/{{ doc_path }}{{ pagename }}.ipynb" class="nav-link" rel="noopener" target="_blank" data-bs-toggle="tooltip" data-bs-original-title="Launch on Binder" data-bs-placement="bottom"><span><i class="fa fa-rocket fa-beat fa-lg"></i></span>
       <label class="sr-only">Launch on Binder</label></a>
   </li>
 </ul>

--- a/docs/source/user_guide/interactive_plots.rst
+++ b/docs/source/user_guide/interactive_plots.rst
@@ -94,7 +94,7 @@ Result:
 
 
 With this you can also easily create whole dashboards like the one
-hosted `here <https://mybinder.org/v2/gh/OpenMS/pyopenms-docs/master+ipynb?urlpath=msbokehapps>`_ on a Binder instance.
+hosted `here <https://notebooks.gesis.org/binder/v2/gh/OpenMS/pyopenms-docs/master+ipynb?urlpath=msbokehapps>`_ on a Binder instance.
 If you are reading/executing this on Binder already, execute the next cell to get a link to your current instance.
 
 .. code-block:: python


### PR DESCRIPTION
mybinder seems to distribute OpenMS sometimes to hubs with less resources than before. this hardcodes one that seems to have enough