### PR TITLE
 Update  User_Guide for Python 3.13.0 compatibility

### DIFF
--- a/docs/source/user_guide/installation.rst
+++ b/docs/source/user_guide/installation.rst
@@ -31,7 +31,7 @@ can type
 We have binary packages for OSX, Linux and Windows (64 bit only) available from
 `PyPI <https://pypi.org/project/pyopenms>`_. Make sure to download
 the 64bit Python release for Windows. Currently we only support
-Python 3.9, 3.10 and 3.11.
+Python 3.9, 3.10, 3.11, 3.12 and 3.13.
 
 You can install Python first from `here <https://www.python.org/downloads/>`_,
 again make sure to download the 64bit release. You can then open a shell and


### PR DESCRIPTION
## Update user_guide for Python 3.13.0 compatibility

### Description

This PR updates the `user_guide` documentation to reflect compatibility with Python 3.13.0.  
Specifically, it modifies the `installation.rst` file to indicate support for Python versions 3.9 through 3.13.

### Checklist

- [x] Updated `installation.rst` to include Python 3.13.0 in the list of supported versions.

### Changes Made

- In the `docs/source/user_guide/installation.rst` file, updated the section specifying supported Python versions to include 3.13.0.

### Related Issue  
Fixes #7874  



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the installation guide to expand compatibility with newer Python releases. The software now supports Python versions 3.9, 3.10, 3.11, 3.12, and 3.13, offering users improved flexibility. These changes ensure accurate, up-to-date information on supported Python environments and empower users by clarifying compatibility with the latest Python setups, enhancing overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->