### PR TITLE
Improved Contrast for Function Signatures in Documentation in Dark Theme

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -70,7 +70,7 @@ p.rubric+dl.py.function {
 /* Parameter names should look a bit different from types */
 .sig-param > span.n:nth-child(1) > .pre {
   font-weight: 500;
-  color: #16324F;
+  color: #3f87d3;
 }
 
 /* In desktop mode, when the top navbar is filled, make the padding to


### PR DESCRIPTION
Fixes #456 

**Description:**
This PR enhances the readability of function signatures in the PyOpenMS documentation in dark theme by increasing the contrast of italicized parameters and type hints. The previous color scheme caused issues where parameters like self, key, and desc blended into the dark background, making them difficult to read.

**Current behavior:**
![Screenshot 2025-03-11 010840](https://github.com/user-attachments/assets/fcf6330e-71a6-44a0-954e-bd77f13d556e)
![Screenshot 2025-03-11 022953](https://github.com/user-attachments/assets/db1eded2-e273-44ef-a46d-f8d42e6d592d)


**After Changes:**
![Screenshot 2025-03-11 010957](https://github.com/user-attachments/assets/538f953b-6051-48b0-9e40-363547e6056f)
![Screenshot 2025-03-11 023132](https://github.com/user-attachments/assets/2436eef5-eb3e-4b30-82d8-2f53fdd9b085)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined the appearance of parameter names in function signatures by updating their color to a brighter blue for improved clarity and consistency.  
   
This update enhances the visual presentation without any other changes to overall styling or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->