### PR TITLE
Added Discord icon to PyOpenMS website

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -70,7 +70,7 @@ p.rubric+dl.py.function {
 /* Parameter names should look a bit different from types */
 .sig-param > span.n:nth-child(1) > .pre {
   font-weight: 500;
-  color: #16324F;
+  color: #3f87d3;
 }
 
 /* In desktop mode, when the top navbar is filled, make the padding to

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -151,6 +151,11 @@ html_theme_options = {
             "type": "fontawesome",
         },
         {
+            "name": "Discord",
+            "url": "https://discord.com/invite/4TAGhqJ7s5",
+            "icon": "fa-brands fa-discord",
+        },
+        {
             "name": "PyPI",
             "url": "https://pypi.org/project/pyopenms",
             "icon": "pypi", # defined in our custom.css


### PR DESCRIPTION
Fixes #460 

**Description:**
The OpenMS community is no longer active on Twitter/X, and the Twitter icon was already removed in a previous PR. This PR adds a Discord icon linking to the OpenMS Discord server, providing an updated way for users to stay engaged.

**Changes Made:**

- Added a Discord icon to the website.
- Linked it to the official OpenMS Discord server.

**Screenshots:**

**🔴 Before (Twitter icon present):**
![Screenshot 2025-03-11 232540](https://github.com/user-attachments/assets/2655ba77-ff93-40d0-9995-fab9e53978c8)
![Screenshot 2025-03-11 232605](https://github.com/user-attachments/assets/6692277b-bcd4-4b6a-8d90-9aad9c575e78)




**✅ After (Discord icon added):**
![Screenshot 2025-03-11 230707](https://github.com/user-attachments/assets/4225b0ef-0c47-4a1e-b936-8acf79d1ee0b)
![Screenshot 2025-03-11 230806](https://github.com/user-attachments/assets/13fe3941-fe5b-49fb-9cc5-3318aeed9525)



**Additional Notes:**
If the maintainers prefer to add any other social media link instead, I can update the PR accordingly. Let me know your thoughts!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Enhanced the visual presentation of Python function parameter names by updating their color for improved clarity.
- **Documentation**
  - Introduced a Discord link with an associated icon in the documentation, offering enhanced navigation and community access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->