### PR TITLE
Replaced Logo with Cropped Rectangular Version (Scale = 1)

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -118,11 +118,6 @@ p.rubric+dl.py.function {
   100% {transform: rotate(-35deg) translate(0px, 0px);}
 }
 
-/* Enlarge logo */
-.navbar-brand img {
-    scale: 1.0
-}
-
 /* In the right tocs:
  The edit pencil icon is a bit bigger than the show source file icon.
  Therefore pad it. */

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -120,7 +120,7 @@ p.rubric+dl.py.function {
 
 /* Enlarge logo */
 .navbar-brand img {
-    scale: 2.0
+    scale: 1.0
 }
 
 /* In the right tocs:

--- a/docs/source/img/pyOpenMSlogo_color.svg
+++ b/docs/source/img/pyOpenMSlogo_color.svg
@@ -1,16 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
-<svg viewBox="0 0 500 500" xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 100 505.9870000000001 294.997" style="max-height: 500px" width="505.9870000000001" height="294.997">
   <defs>
     <clipPath id="clip0">
-      <rect x="0" y="0" width="1280" height="720"/>
+      <rect height="720" width="1280" y="0" x="0"/>
     </clipPath>
   </defs>
-  <g clip-path="url(#clip0)" transform="matrix(1, 0, 0, 1, -388.223431, 47.784692)">
-    <text fill="#C00000" font-family="Arial,Arial_MSFontService,sans-serif" font-weight="700" font-size="80" transform="translate(431.167 292)" style="white-space: pre;">py</text>
-    <text fill="#2F5597" font-family="Arial,Arial_MSFontService,sans-serif" font-weight="700" font-size="80" transform="translate(524.5 292)" style="white-space: pre;">OpenMS</text>
-    <rect x="495" y="130" width="17" height="97" fill="#C00000"/>
-    <rect x="548" y="85" width="16" height="142" fill="#C00000"/>
-    <rect x="598" y="151" width="17" height="76" fill="#C00000"/>
-    <rect x="649" y="197" width="17" height="30" fill="#C00000"/>
+  <g transform="matrix(1, 0, 0, 1, -388.223431, 47.784692)" clip-path="url(#clip0)">
+    <text style="white-space: pre;" transform="translate(431.167 292)" font-size="80" font-weight="700" font-family="Arial,Arial_MSFontService,sans-serif" fill="#C00000">py</text>
+    <text style="white-space: pre;" transform="translate(524.5 292)" font-size="80" font-weight="700" font-family="Arial,Arial_MSFontService,sans-serif" fill="#2F5597">OpenMS</text>
+    <rect fill="#C00000" height="97" width="17" y="130" x="495"/>
+    <rect fill="#C00000" height="142" width="16" y="85" x="548"/>
+    <rect fill="#C00000" height="76" width="17" y="151" x="598"/>
+    <rect fill="#C00000" height="30" width="17" y="197" x="649"/>
   </g>
 </svg>


### PR DESCRIPTION
Fixes #465 

This PR replaces the current logo with a cropped rectangular version, maintaining a scale of 1. The updated logo ensures a more refined and visually consistent appearance while preserving clarity and aspect ratio.

**Screenshots:**

![Screenshot 2025-03-28 013757](https://github.com/user-attachments/assets/45fb731c-586d-429f-8b85-9a7f36a4fb86)
![Screenshot 2025-03-28 014230](https://github.com/user-attachments/assets/1bf7dcfa-8d21-494e-a8d5-768a3b27e9ae)
![Screenshot 2025-03-28 014453](https://github.com/user-attachments/assets/be087eaf-652d-4abd-8fe4-27b10982405a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Removed the enlargement effect on the navigation bar logo, resulting in a smaller and more balanced appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->