### PR TITLE
update pyopenms version numbers

### DIFF
--- a/.github/workflows/test-pr-sphinx.yml
+++ b/.github/workflows/test-pr-sphinx.yml
@@ -21,7 +21,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10' # Version range or exact version of a Python version to use, using SemVer's version range syntax    
+        python-version: '3.11' # Version range or exact version of a Python version to use, using SemVer's version range syntax    
 
     - name: Installing Dependencies
       run: pip install -r docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,6 +8,8 @@ sphinx-remove-toctrees
 ## for pygment coloring of code snippets using ipython syntax
 ipython
 pygments-lexer-pseudocode
+# Dependency of Sphinx, the 3.0 release breaks it (currently)
+snowballstemmer<3
 
 --extra-index-url https://pypi.cs.uni-tuebingen.de/simple/
 pyopenms

--- a/docs/source/_static/switcher.json
+++ b/docs/source/_static/switcher.json
@@ -1,9 +1,14 @@
 [
   {
       "name": "nightly",
-      "version": "3.4.0dev",
+      "version": "3.5.0dev",
       "url": "https://pyopenms.readthedocs.io/en/latest/"
   },
+  {
+    "name": "3.4.0",
+    "version": "3.4.0",
+    "url": "https://pyopenms.readthedocs.io/en/release-3.4.0/"
+},
   {
       "name": "3.3.0",
       "version": "3.3.0",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -86,7 +86,7 @@ author = u'OpenMS Team'
 # built documents.
 #
 # The short X.Y version.
-version = u'3.3.0'
+version = u'3.4.0'
 # The full version, including alpha/beta/rc tags.
 release = version
 rtd_branch = os.environ.get('READTHEDOCS_GIT_IDENTIFIER', '')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-# Dependency of Sphinx, the 3.0 release breaks it (currently)
-snowballstemmer<3
 matplotlib
 plotly
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,7 @@ pyviz_comms
 jupyter-server-proxy
 massql
 sphinx-hoverxref
+# Dependency of Sphinx, the 3.0 release breaks it (currently)
+snowballstemmer<3
 
 pyopenms

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+# Dependency of Sphinx, the 3.0 release breaks it (currently)
+snowballstemmer<3
 matplotlib
 plotly
 pandas
@@ -12,7 +14,6 @@ pyviz_comms
 jupyter-server-proxy
 massql
 sphinx-hoverxref
-# Dependency of Sphinx, the 3.0 release breaks it (currently)
-snowballstemmer<3
+
 
 pyopenms


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Python version used in documentation build workflows to Python 3.11.
	- Added a constraint to the requirements to prevent installing incompatible versions of a documentation dependency.

- **Documentation**
	- Updated the documentation version to 3.4.0.
	- Added a new stable release entry and updated the nightly label in the documentation version switcher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->