### PR TITLE
Semi-specific digestion

### DIFF
--- a/docs/source/user_guide/digestion.rst
+++ b/docs/source/user_guide/digestion.rst
@@ -35,7 +35,7 @@ The other variant allows you to specify minimum and maximum length of peptides p
 
 .. code-block:: cython
 
-    Size digest(protein : pyopenms.AASequence, output : list, min_length : int, max_length : int) -> int
+    digest(protein : pyopenms.AASequence, output : list, min_length : int, max_length : int) -> int
     #   protein - Sequence of the protein to be digested. (pyopenms.AASequence)
     #   output - Empty list. This is where produced peptides will be stored. Warning: if the list is not empty, all its contents will be deleted! (list)
     #   min_length - Minimum length of produced peptide. Shorter products will be discarded. (int)


### PR DESCRIPTION
Add section explaining the newly-implemented semi-specific digestion to `digestion.rst`.
Also add a general section with overview of `ProteaseDigestion.digest()` and its arguments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the in-silico proteolytic digestion documentation with an overview of available tool variants and their usage.
  * Added a new section explaining semi-specific digestion, including example code.
  * Made minor wording improvements for clarity in the Lys-C digestion section.
  * Included a placeholder for future RNase digestion documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->