### PR TITLE
Fix copyright formatting

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -79,7 +79,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'pyOpenMS'
-copyright = u'{date.today().year}, OpenMS Inc'
+copyright = f'{date.today().year}, OpenMS Inc'
 author = u'OpenMS Team'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
Old copyright formatting not rendering properly. Fix this (hopefully)

<img width="472" height="125" alt="image" src="https://github.com/user-attachments/assets/018c0352-cabf-4b9e-97ce-3b2b3b6b0bd6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified documentation build configuration by streamlining how the copyright year is determined.
  * Removed reliance on runtime timestamp functions during builds to ensure a stable, current-year value.
  * Improves clarity and maintainability of documentation metadata and reduces potential build-time variability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->