### PR TITLE
Investigate CI failure in pyopenms-docs PR

### DIFF
--- a/docs/source/user_guide/interactive_plots.rst
+++ b/docs/source/user_guide/interactive_plots.rst
@@ -30,6 +30,14 @@ interactively zoomed-in if you execute the code in a notebook
     loadopts.setIntensity32Bit(True)
     loader.setOptions(loadopts)
     loader.load("../../../src/data/BSA1.mzML", exp)
+
+    # Filter out low-intensity peaks using ThresholdMower
+    threshold_filter = oms.ThresholdMower()
+    params = threshold_filter.getDefaults()
+    params.setValue(b"threshold", 5000.0)
+    threshold_filter.setParameters(params)
+    threshold_filter.filterPeakMap(exp)
+
     exp.updateRanges()
     expandcols = ["RT", "mz", "inty"]
     spectraarrs2d = exp.get2DPeakDataLong(


### PR DESCRIPTION
The CI failure in PR #480 was caused by broken indentation in interactive_plots.rst. The hd.dynspread(...) block was at column 0 instead of being indented with 4 spaces, placing it outside the RST code-block directive.

When notebooks are generated from this RST file, the unindented code becomes markdown text instead of Python code, causing notebook execution to fail.

This commit applies the PR #480 changes (PeptideIdentificationList, get2DPeakDataLong 5th arg, refactored opts) with correct indentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated interactive plots guide with a new low-intensity peak filtering example and revised usage patterns.

* **Refactor**
  * Simplified plotting examples by applying visualization options directly via chaining for clearer, more consistent renders.
  * Peak data extraction example updated to include an additional parameter to improve 2D peak retrieval behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->