### PR TITLE
Add sphinx.ext.napoleon for NumPy-style docstrings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,9 +43,26 @@ extensions = [
     'glossary_warnings',
     'sphinx_copybutton', 'sphinx.ext.autodoc',
     'sphinx.ext.autosummary', 'sphinx.ext.mathjax',
+    'sphinx.ext.napoleon',  # Support NumPy and Google style docstrings
     'sphinx_remove_toctrees',
     'chemrole',
 ]
+
+# Napoleon settings for NumPy-style docstrings
+napoleon_google_docstring = True
+napoleon_numpy_docstring = True
+napoleon_include_init_with_doc = False
+napoleon_include_private_with_doc = False
+napoleon_include_special_with_doc = True
+napoleon_use_admonition_for_examples = False
+napoleon_use_admonition_for_notes = False
+napoleon_use_admonition_for_references = False
+napoleon_use_ivar = False
+napoleon_use_param = True
+napoleon_use_rtype = True
+napoleon_preprocess_types = False
+napoleon_type_aliases = None
+napoleon_attr_annotations = True
 
 ## warn about invalid references (e.g. invalid class names)
 nitpicky = True              


### PR DESCRIPTION
## Summary

Enable proper rendering of NumPy and Google-style docstrings in the pyOpenMS documentation.

This is needed to support docstrings like those in the new statistical functions ([OpenMS/OpenMS#8524](https://github.com/OpenMS/OpenMS/pull/8524)) which use the standard scientific Python docstring format with `Parameters`, `Returns`, `Examples` sections.

## Changes

- Added `sphinx.ext.napoleon` to the extensions list
- Added napoleon configuration settings with sensible defaults

## Why napoleon?

- **Built into Sphinx** - no extra dependency required (available since Sphinx 1.3)
- **Used by pydata-sphinx-theme** - the theme we use includes napoleon in [their own documentation](https://github.com/pydata/pydata-sphinx-theme/blob/main/docs/conf.py)
- **Scientific Python standard** - NumPy-style docstrings are the convention for scientific Python packages

## Docstring rendering

| Environment | Before | After |
|-------------|--------|-------|
| Jupyter / IPython | ✅ Works | ✅ Works |
| ReadTheDocs | ❌ Raw text with `----` underlines | ✅ Properly formatted sections |

## Example

NumPy-style docstrings like this:
```python
def qvalue(p_values, pi0=1.0, pfdr=False):
    """
    Compute q-values from p-values.

    Parameters
    ----------
    p_values : array-like
        Vector of p-values from hypothesis tests

    Returns
    -------
    ndarray
        Vector of q-values
    """
```

Will now render with proper "Parameters" and "Returns" sections in the documentation.

## Test plan

- [ ] Build docs locally and verify docstrings render correctly
- [ ] Check that existing documentation still renders properly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation system to support NumPy and Google-style docstrings for improved API documentation clarity and formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->